### PR TITLE
added netaddr python module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:2
 
-RUN pip install ansible boto boto3
+RUN pip install ansible boto boto3 netaddr
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
the netaddr module is helpful for using the ansible ipaddr module
to calculate ips/subnets etc. in ansible playbooks

https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters_ipaddr.html

secondly when this pull request is merged, a more recent ansible version will be available.
If we want to version pin ansible requirements, we should use a `requirements.txt` or PIPFILE to have explicit versions written down in code