### PR TITLE
revert python to be on version 2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:2
 
 LABEL maintainer="EMnify (https://github.com/EMnify)" \
   org.label-schema.name="Ansible Container" \


### PR DESCRIPTION
Some plugins we are currently utilzing in our CI/CD pipeline are not yet python 3 compatible.
This change reverts the version bump to fix current occuring issues