### PR TITLE
freeze versions of the original image, but update boto3 to support EKS PodIdentity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.9.4
 
 LABEL maintainer="EMnify (https://github.com/EMnify)" \
   org.label-schema.name="Ansible Container" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,17 @@
 ansible==2.9.20
-boto==2.49.0
-boto3==1.16.23
+boto3==1.35.78
 netaddr==0.8.0
+cffi==1.14.5
+cryptography==3.4.7
+Jinja2==2.11.3
+jmespath==0.10.0
+MarkupSafe==1.1.1
+netaddr==0.8.0
+pycparser==2.20
+python-dateutil==2.8.1
+PyYAML==5.4.1
+# s3transfer==0.3.7
+setuptools==56.0.0
+six==1.15.0
+urllib3==1.26.4
+wheel==0.36.2


### PR DESCRIPTION
# Motivation
Make ansible image support EKS PodIdentity and... keep everything else work.

# Description
Based on original working image, frozen the libs versions, and updated only the required for PodIdientity boto3 to the latest version at the time.
```
docker run -it --rm docker.io/emnify/ansible:latest python --version
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Python 3.9.4

docker run -it --rm docker.io/emnify/ansible:latest pip list 
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Package         Version
--------------- -------
ansible         2.9.20
boto            2.49.0
boto3           1.16.23
botocore        1.19.63
cffi            1.14.5
cryptography    3.4.7
Jinja2          2.11.3
jmespath        0.10.0
MarkupSafe      1.1.1
netaddr         0.8.0
pip             21.1
pycparser       2.20
python-dateutil 2.8.1
PyYAML          5.4.1
s3transfer      0.3.7
setuptools      56.0.0
six             1.15.0
urllib3         1.26.4
wheel           0.36.2
```